### PR TITLE
feat(category): Rework how deletion of the category works to prevent accidental deletion)

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,20 @@
+import { Modal } from "@/components/Modal";
+import styles from "./styles.module.css";
+
+type Props = {
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export const ConfirmModal = ({ onCancel, onConfirm }: Props) => (
+  <Modal onClose={onCancel} header={<strong>Are you sure?</strong>}>
+    <div className={styles["flex-container"]}>
+      <button className={`contrast ${styles.flex}`} onClick={onCancel}>
+        No
+      </button>
+      <button className={styles.flex} onClick={onConfirm}>
+        Yes
+      </button>
+    </div>
+  </Modal>
+);

--- a/src/components/styles.module.css
+++ b/src/components/styles.module.css
@@ -1,0 +1,8 @@
+.flex {
+  flex: 1;
+}
+
+.flex-container {
+  display: flex;
+  gap: 1rem;
+}

--- a/src/containers/Categories/Categories.tsx
+++ b/src/containers/Categories/Categories.tsx
@@ -41,6 +41,7 @@ export const Categories = () => {
               key={category.id}
               category={category}
               onDetailClick={(category) => setModalCategory(category)}
+              onDelete={refetch}
             />
           ))
         ) : (

--- a/src/containers/Categories/Category.tsx
+++ b/src/containers/Categories/Category.tsx
@@ -1,20 +1,57 @@
 import { Category as CategoryType } from "@/validators/types";
 import styles from "./styles.module.css";
+import { DatabaseMutationOperation, useLofikMutation } from "@lofik/react";
+import { useState } from "react";
+import { ConfirmModal } from "../../components/ConfirmModal";
 
 type Props = {
   category: CategoryType;
   onDetailClick: (category: CategoryType) => void;
+  onDelete: () => void;
 };
 
-export const Category = ({ category, onDetailClick }: Props) => {
+export const Category = ({ category, onDetailClick, onDelete }: Props) => {
+  const [confirm, setOpenConfirm] = useState<boolean>(false);
+
+  const { mutate } = useLofikMutation({
+    shouldSync: true,
+    onSuccess: () => {},
+  });
+
+  const handleDelete = async () => {
+    // Todo: solve why VSCode says its not needed, but in fact its very needed!
+    await mutate({
+      operation: DatabaseMutationOperation.Delete,
+      tableName: "categories",
+      identifierValue: category.id as string,
+    });
+
+    setOpenConfirm(false);
+    onDelete();
+  };
+
   return (
-    <div
-      className={styles["category-row"]}
-      onClick={() => onDetailClick(category)}
-    >
-      <p>
+    <>
+      <div
+        className={styles["category-row"]}
+        onClick={() => onDetailClick(category)}
+      >
         <strong>{category.title}</strong>
-      </p>
-    </div>
+        <div
+          onClick={(e) => {
+            e.stopPropagation(); // Prevent whole row-click event
+            setOpenConfirm(true);
+          }}
+        >
+          🗑️
+        </div>
+      </div>
+      {confirm && (
+        <ConfirmModal
+          onCancel={() => setOpenConfirm(false)}
+          onConfirm={handleDelete}
+        />
+      )}
+    </>
   );
 };

--- a/src/containers/Categories/CategoryFormModal.tsx
+++ b/src/containers/Categories/CategoryFormModal.tsx
@@ -54,13 +54,6 @@ export const CategoryFormModal = ({ category, onSuccess, onClose }: Props) => {
     });
   };
 
-  const onDelete = async () =>
-    mutate({
-      operation: DatabaseMutationOperation.Delete,
-      tableName: "categories",
-      identifierValue: category.id as string,
-    });
-
   return (
     <Modal
       onClose={onClose}
@@ -82,16 +75,6 @@ export const CategoryFormModal = ({ category, onSuccess, onClose }: Props) => {
         </fieldset>
 
         <div className={styles["flex-container"]}>
-          {category.id && (
-            <button
-              type="button"
-              className={`contrast ${styles.flex}`}
-              onClick={onDelete}
-            >
-              delete
-            </button>
-          )}
-
           <button className={styles.flex} type="submit">
             {category.id ? "save" : "add"}
           </button>

--- a/src/containers/Categories/styles.module.css
+++ b/src/containers/Categories/styles.module.css
@@ -8,6 +8,7 @@
   margin-bottom: 0.5rem;
   padding: 0.5rem;
   border-radius: 5px;
+  justify-content: space-between;
 }
 
 .category-row:hover {


### PR DESCRIPTION
Current (edit/delete) category dialog has an issue that it looks like `[Cancel]` `[Submit]`. Also there is no confirmation for the deletion of the category.

![image](https://github.com/pycan-jouza/lofextra/assets/89867413/dcfd08f6-1c25-4247-843d-ab998f873eed)


This PR attempts to improve this issue by moving deletion out of the edit form and adding the confirmation dialog.
![image](https://github.com/pycan-jouza/lofextra/assets/89867413/e769a5f2-634a-44b2-9963-79747430fda3)
![image](https://github.com/pycan-jouza/lofextra/assets/89867413/855a472a-49c3-4131-b5f1-12c21f4e5abe)
![image](https://github.com/pycan-jouza/lofextra/assets/89867413/8afe769b-b669-4ec0-b089-7cbad3ff403a)
