### PR TITLE
feat(transactions): Change inputMethod so the + sign is available on android

### DIFF
--- a/src/containers/Transactions/TransactionFormModal.tsx
+++ b/src/containers/Transactions/TransactionFormModal.tsx
@@ -129,7 +129,7 @@ export const TransactionFormModal = ({ transaction, onClose }: Props) => {
               name="amount"
               placeholder="5+5"
               aria-label="amount"
-              inputMode="numeric"
+              inputMode="tel"
             />
           </div>
         </fieldset>


### PR DESCRIPTION
With `numeric` input-mode on Android, it is hard/impossible (depends on your keyboard app) to use `+` sign. Using `tel` input mode makes it easier. 

We are not entering only number, but expression so it makes sense not use `numeric` and `tel` seems to me as very good hack how to get number keyboard, but with option to get all other symbols.


Before: 
![image](https://github.com/pycan-jouza/lofextra/assets/89867413/d0cf8e9b-6e65-4dd2-a0cc-ff5f1f89f6bd)


After: 
![image](https://github.com/pycan-jouza/lofextra/assets/89867413/8a4e6183-3845-4509-b7af-e34818760c99)
